### PR TITLE
[Autoencoder] Code cleanup and auto-determination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# .gitignore for the AMQ-Scripts project
+
+##IDE / Dev env files##
+###Komodo IDE/Edit###
+*.komodoproject
+.komodotools
+
+###Notepad++###
+*.bak
+
+##Python files##
+__pycache__/
+__pycache__/*
+*.pyc
+
+##auto-encoder output##
+outputfiles/
+outputfiles/*
+*.log
+*.webm
+*.mp3
+*.mkv
+*.mka
+*dummy*
+currentnumber.txt
+*.bat
+
+##Feel free to add anything I missed##

--- a/encoding/autoencoder/autoconvert.py
+++ b/encoding/autoencoder/autoconvert.py
@@ -6,6 +6,9 @@ adjust audio volume and use a standard formula for output
 Dependent on:
 mediainfo
 ffmpeg
+
+Author: Zolhungaj
+        FokjeM / Riven Skaye (really minor tweaks)
 """
 import re
 import os

--- a/encoding/autoencoder/autoconvert.py
+++ b/encoding/autoencoder/autoconvert.py
@@ -15,22 +15,16 @@ import os
 import datetime
 import time
 import subprocess
-global logfile
 # dependencies:
 # mediainfo, tested on v18.05
 # ffmpeg, tested on N-91538-g269daf5985
 #
 logfile = "AMQ-autoconvert.log"
-global mediainfo
 mediainfo = "mediainfo"  # command to invoke mediainfo, eg C:mediainfo.exe
-global ffmpeg
 ffmpeg = "ffmpeg"  # command to invoke ffmpeg, eg C:ffmpeg\bin\ffmpeg.exe
 # global ffprobe = "ffprobe"
-global outputFolder
 outputFolder = "outputfiles\\"  # path to output folder
-global maxmean
 maxmean = -16.0
-global maxpeak
 maxpeak = -1.0
 
 

--- a/encoding/autoencoder/autorescheck.py
+++ b/encoding/autoencoder/autorescheck.py
@@ -1,29 +1,28 @@
 """
 Simple piece of code that checks the current video quality
 and then returns the best AMQ option.
+
+Author: FokjeM / RivenSkaye
 """
 import os
 import subprocess
 import datetime
 import time
-global mediainfo
-global logfile
+mediainfo = "mediainfo"
 logfile = "AMQ-autorescheck.log"
-if "\\mediainfo" in str.lower(os.environ['PATH']):
-    mediainfo = "mediainfo"
-else:
+if "\\mediainfo" not in str.lower(os.environ['PATH']):
     log("MediaInfo not found on path.")
     try:
-        subprocess.call("C:\\Program\ Files\\MediaInfo\\MediaInfo.exe");
+        subprocess.check_call("C:\\Program\ Files\\MediaInfo\\MediaInfo.exe");
         mediainfo = "C:\\Program\ Files\\MediaInfo\\MediaInfo.exe"
-    except:
+    except CalledProcessError:
         log("MediaInfo not installed in Program Files.")
         try:
-            subprocess.call("C:\\Program\ Files\ (x86)\\MediaInfo\\MediaInfo.exe");
+            subprocess.check_call("C:\\Program\ Files\ (x86)\\MediaInfo\\MediaInfo.exe");
             mediainfo = "C:\\Program\ Files\ (x86)\\MediaInfo\\MediaInfo.exe"
-        except:
+        except CalledProcessError:
             log("MediaInfo not found in Program Files (x86).")
-            print("MediaInfo was not found on your system, it is a dependency for this script\r\nGet it at: https://mediaarea.net/en/MediaInfo\r\nIf you already have the CLI version, add it to your PATH.")
+            log("MediaInfo was not found on your system, it is a dependency for this script\r\nGet it at: https://mediaarea.net/en/MediaInfo\r\nIf you already have the CLI version, add it to your PATH.")
             exit()
 
 def autorescheck(inputfile):
@@ -31,11 +30,11 @@ def autorescheck(inputfile):
     command = '%s "%s" --output=Video;%%Height%%' % (mediainfo, inputfile)
     process = os.popen(command)
     height = int(process.read())
-    if height <= 480:
+    if height <= 480: # 480 or worse, should be encoded as AMQ 480p
         return "9"
-    elif height < 720:
+    elif height < 720: # This falls under the 576p category, because we know it's more than 480p
         return "8"
-    else:
+    else: # It's 720p or better. Someone has quality content!
         return "7"
 
 def log(message):

--- a/encoding/autoencoder/autorescheck.py
+++ b/encoding/autoencoder/autorescheck.py
@@ -1,0 +1,52 @@
+"""
+Simple piece of code that checks the current video quality
+and then returns the best AMQ option.
+"""
+import os
+import subprocess
+import datetime
+import time
+global mediainfo
+global logfile
+logfile = "AMQ-autorescheck.log"
+if "\\mediainfo" in str.lower(os.environ['PATH']):
+    mediainfo = "mediainfo"
+else:
+    log("MediaInfo not found on path.")
+    try:
+        subprocess.call("C:\\Program\ Files\\MediaInfo\\MediaInfo.exe");
+        mediainfo = "C:\\Program\ Files\\MediaInfo\\MediaInfo.exe"
+    except:
+        log("MediaInfo not installed in Program Files.")
+        try:
+            subprocess.call("C:\\Program\ Files\ (x86)\\MediaInfo\\MediaInfo.exe");
+            mediainfo = "C:\\Program\ Files\ (x86)\\MediaInfo\\MediaInfo.exe"
+        except:
+            log("MediaInfo not found in Program Files (x86).")
+            print("MediaInfo was not found on your system, it is a dependency for this script\r\nGet it at: https://mediaarea.net/en/MediaInfo\r\nIf you already have the CLI version, add it to your PATH.")
+            exit()
+
+def autorescheck(inputfile):
+    print("Using automatic determination for video resolution!")
+    command = '%s "%s" --output=Video;%%Height%%' % (mediainfo, inputfile)
+    process = os.popen(command)
+    height = int(process.read())
+    if height <= 480:
+        return "9"
+    elif height < 720:
+        return "8"
+    else:
+        return "7"
+
+def log(message):
+    """
+    Borrowed Zol's code here
+    This functions logs to a file, given by the logfile global
+    """
+    # write timestamp message newline to file
+    msg = "[%s]: %s\n" % (datetime.datetime.fromtimestamp(
+        datetime.datetime.now().timestamp()).isoformat(), message)
+    file = open(logfile, "a", encoding="utf-8")
+    file.write(msg)
+    file.close()
+    print(msg)

--- a/encoding/autoencoder/interface.py
+++ b/encoding/autoencoder/interface.py
@@ -6,7 +6,7 @@ Tries to check what kind of file the user is offering
 so the user doesn't have to do anything.
 
 Author: Zolhungaj
-        FokjeM / RivenSkaye (really minor tweaks)
+        FokjeM / RivenSkaye (minor tweaks)
 """
 
 from autoconvert import autoconvert
@@ -46,7 +46,8 @@ while True:
         crf = -1  # default value
         try:
             targetResolution = choice[target]
-        except:
+        # Any illegal value causes auto-determination to run.
+        except KeyError:
             targetResolution = choice[autorescheck(filename)]
         # range(a, b) is inclusive a and exclusive b!
         if (targetResolution in range(-3, 0)):
@@ -66,6 +67,7 @@ while True:
                 if crf < 0 or crf > 63:
                     print("%d is not in the range [0-63]")
                     continue
+                break
         break
     animeTitle = input(
         "Please enter anime name, this will be used to name the file\n\t")
@@ -170,7 +172,7 @@ while True:
     except Exception as e:
         print("During execution, an exception occured:%s" % str(e))
     print("")
-    cont = input("Would you like to continue?(y/[n])")
+    cont = str.lower(input("Would you like to continue?(y/[n])")) # Make sure we don't exit on capital Y
     if cont == "":
         break
     elif cont[0] == "y":

--- a/encoding/autoencoder/interface.py
+++ b/encoding/autoencoder/interface.py
@@ -1,4 +1,16 @@
+""""
+The part of the program the user should be using.
+Presents them with a CLI that asks for file info.
+
+Tries to check what kind of file the user is offering
+so the user doesn't have to do anything.
+
+Author: Zolhungaj
+        FokjeM / RivenSkaye (really minor tweaks)
+"""
+
 from autoconvert import autoconvert
+from autorescheck import autorescheck
 import os
 import re
 print("Welcome to the autoconverter interface")
@@ -25,34 +37,19 @@ while True:
             5: All-AMQ submit order (720p, Source, 480p, mp3)
             6: unscaled (like 720p but for esoteric sizes)
             7: AMQ-720 source is 720 or higher (720p, mp3, 480p)
-            8: AMQ-576 source is 576 or higher (unscaled, 480, mp3)
+            8: AMQ-576 source is 576 or at least higher than 480 (unscaled, 480p, mp3)
             9: AMQ-480 source is 480 or lower (unscaled, mp3)
+            Leave blank for auto-determination mode, we'll figure out the details for you.
             \t""")
+        choice = {"0" : 0, "mp3" : 0, "1" : 480, "480p" : 480, "2" : 720, "720p" : 720, "3" : -1, "source" : -1, "4" : -2, "all" : -2, "all-amq" : -2, "5" : -3, "amq-720" : -3, "6" : -4, "unscaled" : -4, "7" : -5, "amq" : -5, "8" : -6, "amq-576" : -6, "9" : -7, "amq-480" : -7}
         target = target.lower()
         crf = -1  # default value
-        if target == "0" or target == "mp3":
-            targetResolution = 0
-        elif target == "1" or target == "480p":
-            targetResolution = 480
-        elif target == "2" or target == "720p":
-            targetResolution = 720
-        elif target == "6" or target == "unscaled":
-            targetResolution = -4
-        elif target == "7" or target == "amq":
-            targetResolution = -5
-        elif target == "8" or target == "amq-576":
-            targetResolution = -6
-        elif target == "9" or target == "amq-480":
-            targetResolution = -7
-        elif (target == "3" or target == "source" or target == ""
-              or target == "4" or target == "all"
-              or target == "5" or target == "all-amq"):
-            if target == "3" or target == "source" or target == "":
-                targetResolution = -1
-            if target == "5" or target == "amq-720":
-                targetResolution = -3
-            else:
-                targetResolution = -2
+        try:
+            targetResolution = choice[target]
+        except:
+            targetResolution = choice[autorescheck(filename)]
+        # range(a, b) is inclusive a and exclusive b!
+        if (targetResolution in range(-3, 0)):
             while True:
                 try:
                     string = input(
@@ -69,10 +66,6 @@ while True:
                 if crf < 0 or crf > 63:
                     print("%d is not in the range [0-63]")
                     continue
-                break
-        else:
-            print('"%s" is not a valid choice' % target)
-            continue
         break
     animeTitle = input(
         "Please enter anime name, this will be used to name the file\n\t")


### PR DESCRIPTION
Addition:
- Option to auto-determine what resolution to output.
    - Could be added to autoconvert instead, but seems a bit out of place imho.
    - I borrowed Zol's `log(msg)` function for this one.
- Option for automatic determination of resolution

Changes:
- Replaced the endless `if-elif-else` in `interface` with a dictionary.
- Replaced the warning for illegal input without determination.
- Removed redundant `global` identifiers.
- Added a p in `interface` for consistency.
- Make sure capitalization doesn't cause an unwanted halt.