### PR TITLE
feat(amqAutocomplete.user.js): allow for shift-tab to go backwards

### DIFF
--- a/gameplay/amqAutocomplete.user.js
+++ b/gameplay/amqAutocomplete.user.js
@@ -461,7 +461,8 @@ if (!isNode) {
 				else if (e.keyCode == 39 && options.allowRightLeftArrows) this.next();
 				else if (e.keyCode == 9 && options.allowTab) {
 					e.preventDefault();
-					this.next();
+					if (e.shiftKey) this.previous();
+					else this.next();
 				}
 			})
 		}


### PR DESCRIPTION
Update autocomplete when `allowTab: true` to additionally allow the user to do shift+tab to go to the previous result.