### PR TITLE
amqAutocomplete: Add new option for submit functionality

### DIFF
--- a/gameplay/amqAutocomplete.user.js
+++ b/gameplay/amqAutocomplete.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Amq Autocomplete improvement
 // @namespace    http://tampermonkey.net/
-// @version      1.39
+// @version      1.40
 // @description  faster and better autocomplete
 // First searches for text startingWith, then includes and finally if input words match words in anime (in any order). Special characters can be in any place in any order
 // @author       Juvian
@@ -38,6 +38,7 @@ var options = {
 	allowRightLeftArrows: false, // use right and left arrows to move dropdown selected options
 	allowTab: false,
 	submitOnSelect: false,
+	disableModifiedSubmit: false, // if true, disables the script's auto-submit of the top suggestion and uses the base AMQ submit behavior instead
 	fuzzy: {
 		dropdown: true, // whether to show fuzzy matches if no matches found
 		answer: true, // whether to use top fuzzy match on round end as answer if no matches found
@@ -524,7 +525,15 @@ if (!isNode) {
 	    try{
 			var awesome = this.autoCompleteController.awesomepleteInstance;
 
-			if(options.enabled && awesome && awesome.input.value == awesome.filterManager.lastStr && awesome.suggestions && awesome.input.value.trim() && awesome.suggestions.slice(1).every(s => cleanString(s.value) != cleanString(awesome.input.value)) && (awesome.suggestions.length || (!options.fuzzy.dropdown && options.fuzzy.answer))) {
+			if(
+				options.enabled && 
+				!options.disableModifiedSubmit &&
+				awesome && 
+				awesome.input.value == awesome.filterManager.lastStr && 
+				awesome.suggestions && 
+				awesome.input.value.trim() && 
+				awesome.suggestions.slice(1).every(s => cleanString(s.value) != cleanString(awesome.input.value)) && 
+				(awesome.suggestions.length || (!options.fuzzy.dropdown && options.fuzzy.answer))) {
 				awesome.input.value = awesome.suggestions.length ? awesome.suggestions[0].value : awesome.filterManager.filterBy(awesome.input.value, true)[0].originalStr;
 			}
 		} catch (ex) {


### PR DESCRIPTION
The amqAutocomplete script currently overrides `submitAnswer` to auto-submit the top suggestion or fuzzy search result. This PR adds an option to disable the auto-submit behavior, allowing users (me) to keep the original submit while retaining the improved sorting feature.

Was unsure if I should have changed the version to 1.4 or 1.391

Thank you. 